### PR TITLE
V0.07.03a-makebuild-bugfix

### DIFF
--- a/Bugs/FileCreationError.isu
+++ b/Bugs/FileCreationError.isu
@@ -1,2 +1,2 @@
 1 | TOP:  |  ./makebuild.sh
-2 | 5  |   Upon execution, creates a random blank file titled either 1 or 2. REQUIRES BUG REPORT
+2 | 5  |   The random blank file is actually titled the exit status of the program.

--- a/makebuild.sh
+++ b/makebuild.sh
@@ -1,110 +1,39 @@
 #!/usr/bin/env bash
-# Requires options BUILDFILE, BUILDNAME, Distribute option
+# Requires options BUILDFILE, BUILDNAME, DISTRIBUTE_FLAG
 # BUILDNAME should be the same as the BUILDFILE, without .py...
 
-# TODO BUG FileCreationError: Upon execution, creates a random blank file titled either 1 or 2. REQUIRES BUG REPORT
+# TODO BUG FileCreationError: The random blank file is actually titled the exit status of the program.
 
-if [ $(cat $1 | grep -c "# TODO") > 1 ]; then
+if [ $(cat $1 | grep -c "# TODO") > 0 ]; then
     echo "There are TODO's that require attention, would you like to review them? [y/n]"
     say "There are TODO's that require your attention!"
     read checkfortodo
     if [ "$checkfortodo" == "y" ]; then
         cat $1 | grep "# TODO"
-        echo "Would you still like to build? [y/n]"
+        echo "Build? [y/n]"
         read checkforbuild
-        if [ "$checkforbuild" == "y" ]; then
-            echo "Building $1!"
-            #echo "Removing old build files..."
-            #rm -r build &> /dev/null
-            #rm -r dist &> /dev/null
-            #rm -r $2.spec &> /dev/null
-
-            # UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
-            say "Performing build!"
-            pyinstaller -F -c $1
-
-            if [ "$3" == "dist" ]; then
-                echo "Removing old binary '$2' from /usr/local/bin/ and copying the new one."
-                rm /usr/local/bin/$2
-                cp ./dist/$2 /usr/local/bin/$2
-            fi
-
-            echo "Done!"
-            # UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
-            say "Done!"
-            echo ""
-            echo "Testing build..."
-            $2 -v
-        else echo "Exiting!"; say "Exiting!"; exit
+        if [ "$checkforbuild" == "n" ]; then
+            echo "Exiting!"; say "Exiting"; exit
         fi
-        exit
-    else
-        #echo "Removing old build files..."
-        #rm -r build &> /dev/null
-        #rm -r dist &> /dev/null
-        #rm -r $2.spec &> /dev/null
-
-        echo "Performing build..."
-        # UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
-        say "Performing build!"
-        pyinstaller -F -c $1
-
-        if [ "$3" == "dist" ]; then
-            echo "Removing old binary '$2' from /usr/local/bin/ and copying the new one."
-            rm /usr/local/bin/$2
-            cp ./dist/$2 /usr/local/bin/$2
-        fi
-        echo "Done!"
-        # UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
-        say "Done!"
-        echo ""
-        echo "Testing build..."
-        $2 -v
     fi
-else
-    #echo "Removing old build files..."
-    #rm -r build &> /dev/null
-    #rm -r dist &> /dev/null
-    #rm -r $2.spec &> /dev/null
-
-    echo "Performing build..."
-    # UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
-    say "Performing build!"
-    pyinstaller -F -c $1
-
-    if [ "$3" == "dist" ]; then
-        echo "Removing old binary '$2' from /usr/local/bin/ and copying the new one."
-        rm /usr/local/bin/$2
-        cp ./dist/$2 /usr/local/bin/$2
-    fi
-
-    echo "Done!"
-    # UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
-    say "Done!"
-    echo ""
-    echo "Testing build..."
-    $2 -v
 fi
 
-#echo "Removing old build files..."
-#rm -r build &> /dev/null
-#rm -r dist &> /dev/null
-#rm -r $2.spec &> /dev/null
+echo "Building $1!"
 
-#echo "Performing build..."
-## UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
-#say "Performing build!"
-#pyinstaller -F -c $1
-#
-#if [ "$3" == "dist" ]; then
-#    echo "Removing old binary '$2' from /usr/local/bin/ and copying the new one."
-#    rm /usr/local/bin/$2
-#    cp ./dist/$2 /usr/local/bin/$2
-#fi
-#
-#echo "Done!"
-## UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
-#say "Done!"
-#echo ""
-#echo "Testing build..."
-#$2 -v
+# UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
+say "Performing build!"
+pyinstaller -F -c -n "$2" "$1"
+
+if [ "$3" == "dist" ]; then
+    echo "Removing old binary '$2' from /usr/local/bin/ and copying the new one."
+    rm /usr/local/bin/$2
+    cp ./dist/$2 /usr/local/bin/$2
+fi
+
+echo "Done!"
+# UNCOMMENT SAY LINES FOR NON MACOSX SYSTEMS
+say "Done!"
+echo ""
+echo "Testing build..."
+./dist/$2 -v
+


### PR DESCRIPTION
Rewrite of the ./makebuild.sh script, initial analysis of the FileCreationBug. Updates to FileCreationBug.isu, and support for named builds (i.e "PingStats.py" becomes "pingstats<insert version number>").

Due to the simple nature of the updates in this pull request, I do not believe this should be a new version. 

BootstrapperLogic needs to be fixed before we can move to V0.07.04a